### PR TITLE
Add uploads.ini script for PHP directives

### DIFF
--- a/imageroot/actions/create-module/10uploads.ini
+++ b/imageroot/actions/create-module/10uploads.ini
@@ -9,10 +9,10 @@
 
 mkdir -vp config
 cat <<EOF > config/uploads.ini
-memory_limit = 512M
-upload_max_filesize = 256M
-post_max_size = 256M
-max_execution_time = 300
-max_input_time = 300
-max_file_uploads = 50
+memory_limit=512M
+upload_max_filesize=256M
+post_max_size =256M
+max_execution_time=600
+max_input_time=600
+max_file_uploads=50
 EOF

--- a/imageroot/actions/create-module/10uploads.ini
+++ b/imageroot/actions/create-module/10uploads.ini
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# This script is used to create a uploads.ini fro php directives
+
+mkdir -vp config
+cat <<EOF > config/uploads.ini
+memory_limit = 512M
+upload_max_filesize = 256M
+post_max_size = 256M
+max_execution_time = 300
+max_input_time = 300
+max_file_uploads = 50
+EOF

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -6,5 +6,5 @@
 
 
 state/wordpress.sql
+state/config/uploads.ini
 volumes/wordpress-app
-

--- a/imageroot/systemd/user/wordpress-app.service
+++ b/imageroot/systemd/user/wordpress-app.service
@@ -22,7 +22,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/wordpress-app.pid \
     --cidfile %t/wordpress-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/wordpress.pod-id --replace -d --name  wordpress-app \
     --volume wordpress-app:/var/www/html/:Z \
-    --volume ./config/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini \
+    --volume ./config/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini:Z \
     --env=WORDPRESS_* \
     --env WORDPRESS_DB_TYPE="mysql" \
     --env WORDPRESS_DB_HOST=127.0.0.1 \

--- a/imageroot/systemd/user/wordpress-app.service
+++ b/imageroot/systemd/user/wordpress-app.service
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/wordpress-app.pid \
     --cidfile %t/wordpress-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/wordpress.pod-id --replace -d --name  wordpress-app \
     --volume wordpress-app:/var/www/html/:Z \
+    --volume ./config/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini \
     --env=WORDPRESS_* \
     --env WORDPRESS_DB_TYPE="mysql" \
     --env WORDPRESS_DB_HOST=127.0.0.1 \


### PR DESCRIPTION
This pull request adds a script for creating an uploads.ini file that contains PHP directives. The script creates the file with the following directives:

- upload_max_filesize: 256M

- post_max_size: 256M

- max_execution_time: 300

- max_input_time: 300

The script also includes the necessary changes to include the uploads.ini file in the state-include.conf and to mount it in the wordpress-app service.