### PR TITLE
Enable and restart wordpress.service

### DIFF
--- a/imageroot/actions/configure-module/80start_services
+++ b/imageroot/actions/configure-module/80start_services
@@ -13,4 +13,5 @@ exec 1>&2
 
 touch smarthost.env
 
-systemctl --user enable --now wordpress.service
+systemctl --user enable  wordpress.service
+systemctl --user restart wordpress.service


### PR DESCRIPTION
This pull request enables and restarts the wordpress.service. Previously, the service was only enabled but not restarted. This change ensures that the service is both enabled and restarted, allowing for any necessary updates or changes to take effect.