### PR TITLE
Add slirp4netns network to allow access to host

### DIFF
--- a/imageroot/systemd/user/wordpress.service
+++ b/imageroot/systemd/user/wordpress.service
@@ -21,6 +21,7 @@ TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/wordpress.pid %t/wordpress.pod-id
 ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/wordpress.pid \
     --pod-id-file %t/wordpress.pod-id \
+    --network slirp4netns:allow_host_loopback=true \
     --name wordpress \
     --publish 127.0.0.1:${TCP_PORT}:80 \
     --replace


### PR DESCRIPTION
Due to pasta network the access to the host isn't possible so the health check fails.
The health check works when adding `--network slirp4netns:allow_host_loopback=true`
Refs NethServer/dev#7649